### PR TITLE
[TASK] Iterate over characters

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -264,7 +264,7 @@ class Parser implements ParserInterface
                     $fragment_index_offset = $from_base_fragment_length;
 
                     // iterate until no more match
-                    for (;;) {
+                    do {
                         $fragment_from_index = $from_base_fragment_index + $fragment_index_offset;
 
                         if ($fragment_from_index >= $from_segment_end) {
@@ -283,7 +283,7 @@ class Parser implements ParserInterface
 
                         $fragment_length = mb_strlen($from_fragments[$fragment_from_index]);
                         $fragment_index_offset += $fragment_length;
-                    }
+                    } while(true);
 
                     if ($fragment_index_offset > $best_copy_length) {
                         $best_copy_length = $fragment_index_offset;
@@ -426,10 +426,8 @@ class Parser implements ParserInterface
         $currentFragmentString = '';
         $fragmentStartPosition = 0;
         $foundDelimiterInFragment = false;
-        for ($currentPosition = 0; $currentPosition < $charCount; $currentPosition++) {
-            // @todo: Using mb_str_split() before the loop once is significantly quicker than using
-            //        mb_substr() for each char of the text and mb_strlen() won't be needed.
-            $character = mb_substr($text, $currentPosition, 1, 'UTF-8');
+        $chars = mb_str_split($text, 1, 'UTF-8');
+        foreach($chars as $currentPosition => $character) {
             $isDelimiterCharacter = in_array($character, $delimiters, true);
             if ($isDelimiterCharacter) {
                 $currentFragmentString .= $character;

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -283,7 +283,7 @@ class Parser implements ParserInterface
 
                         $fragment_length = mb_strlen($from_fragments[$fragment_from_index]);
                         $fragment_index_offset += $fragment_length;
-                    } while(true);
+                    } while (true);
 
                     if ($fragment_index_offset > $best_copy_length) {
                         $best_copy_length = $fragment_index_offset;
@@ -427,7 +427,7 @@ class Parser implements ParserInterface
         $fragmentStartPosition = 0;
         $foundDelimiterInFragment = false;
         $chars = mb_str_split($text, 1, 'UTF-8');
-        foreach($chars as $currentPosition => $character) {
+        foreach ($chars as $currentPosition => $character) {
             $isDelimiterCharacter = in_array($character, $delimiters, true);
             if ($isDelimiterCharacter) {
                 $currentFragmentString .= $character;


### PR DESCRIPTION
As discussed on typo3.slack.com, here's my contribution to improving the performance of finediff.

The complexity of splitting a string once into an array and iterating over it is O(2n) as where having to `mb_substr` for each character is O(n^2). This can lead to quite harsh performance issues when trying to calculate a diff for longer texts.

See the TYPO3 [TypoScript Tokenizer][1] for another example of this implementation.
[1]: https://review.typo3.org/c/Packages/TYPO3.CMS/+/74285/28..29/typo3/sysext/core/Classes/TypoScript/Tokenizer/Tokenizer.php