### PR TITLE
[TASK] Raise phpunit min-versions to avoid prophecy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,7 @@ jobs:
         run: find src/ tests/ -name '*.php' -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
 
       - name: Install dependencies
-        if: ${{ matrix.php <= '8.1' }}
         run: composer update
-
-      - name: Install dependencies PHP 8.2
-        if: ${{ matrix.php > '8.1' }}
-        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-        run: composer update --ignore-platform-req=php+
 
       - name: CGL check
         if: ${{ matrix.php == '7.2' }}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/polyfill-mbstring": "^1.23"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8 || ^9",
+        "phpunit/phpunit": "^8.5.29 || ^9.5.24",
         "friendsofphp/php-cs-fixer": "^3.4",
         "phpstan/phpstan": "^1.6"
     },


### PR DESCRIPTION
With phpunit dropping prophecy dependency, we can avoid a CI PHP 8.2 related hack again.