### PR TITLE
[TASK] Require PHP mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "type": "library",
     "require": {
         "php": ">=8.2",
-        "symfony/polyfill-mbstring": "^1.23"
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.10 || ^11.0.2",


### PR DESCRIPTION
It should be fair to require true mbstring
for this package with 1.1.

> composer req ext-mbstring:*
> composer rem symfony/polyfill-mbstring