### PR TITLE
[TASK] Prevent PHP 8.4 deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3']
+        php: ['8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4
@@ -36,9 +36,11 @@ jobs:
         run: composer update
 
       - name: CGL check
+        if: ${{ matrix.php <= '8.3' }}
         run: vendor/bin/php-cs-fixer fix --diff --dry-run
 
       - name: Phpstan
+        if: ${{ matrix.php <= '8.3' }}
         run: vendor/bin/phpstan analyze --no-progress
 
       - name: Phpunit

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0.3",
+        "phpunit/phpunit": "^11.2.6",
         "friendsofphp/php-cs-fixer": "^3.50.0",
         "phpstan/phpstan": "^1.10.57"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
     cacheDirectory=".phpunit.cache"
     cacheResult="false"
     colors="true"
     failOnRisky="true"
     failOnWarning="true"
+    failOnDeprecation="true"
 >
     <testsuites>
         <testsuite name="Unit">

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -50,7 +50,7 @@ class Diff
      * @param RendererInterface|null $renderer Diff renderer.
      * @param ParserInterface|null $parser Parser used to generate opcodes.
      */
-    public function __construct(GranularityInterface $granularity = null, RendererInterface $renderer = null, ParserInterface $parser = null)
+    public function __construct(?GranularityInterface $granularity = null, ?RendererInterface $renderer = null, ?ParserInterface $parser = null)
     {
         $this->granularity = $granularity ?? new Character();
         $this->renderer = $renderer ?? new Html();


### PR DESCRIPTION
Add PHP 8.4 to test matrix. php-cs-fixer
and phpstan are not ready yet, skipped.

Update Diff->__construct() to avoid
"Implicit nullable" PHP 8.4 deprecations.

> composer req --dev phpunit/phpunit:^11.2.6