### PR TITLE
[TASK] Prevent PHP 8.4 deprecation (#38)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -50,7 +50,7 @@ class Diff
      * @param RendererInterface|null $renderer Diff renderer.
      * @param ParserInterface|null $parser Parser used to generate opcodes.
      */
-    public function __construct(GranularityInterface $granularity = null, RendererInterface $renderer = null, ParserInterface $parser = null)
+    public function __construct(?GranularityInterface $granularity = null, ?RendererInterface $renderer = null, ?ParserInterface $parser = null)
     {
         $this->granularity = $granularity ?? new Character();
         $this->renderer = $renderer ?? new Html();


### PR DESCRIPTION
Add PHP 8.4 to test matrix.

Update Diff->__construct() to avoid
"Implicit nullable" PHP 8.4 deprecations.