### PR TITLE
[TASK] Bump php-cs-fixer, activate null checks

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -53,6 +53,10 @@ return (new PhpCsFixer\Config())
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_whitespace_in_blank_line' => true,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => true,
         'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
         'php_unit_mock_short_will_return' => true,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.2.6",
-        "friendsofphp/php-cs-fixer": "^3.50.0",
+        "friendsofphp/php-cs-fixer": "^3.59.3",
         "phpstan/phpstan": "^1.10.57"
     },
     "replace": {


### PR DESCRIPTION
To prevent new PHP 8.4 issues, php-cs-fixer
is raised and the 'null' checks are enabled.

> composer req --dev friendsofphp/php-cs-fixer:^3.59.3