### PR TITLE
[TASK] GH actions: Skip phpstan with PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         run: vendor/bin/php-cs-fixer fix -v --diff --dry-run --show-progress none
 
       - name: Phpstan
+        if: ${{ matrix.php <= '8.3' }}
         run: vendor/bin/phpstan analyze --no-progress
 
       - name: Phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^11.5.7 || ^12.0.2",
         "friendsofphp/php-cs-fixer": "^3.69.0",
-        "phpstan/phpstan": "^2.1.5"
+        "phpstan/phpstan": "^2.1.7"
     },
     "replace": {
         "cogpowered/finediff": "*"


### PR DESCRIPTION
Youngest phpstan deviate with PHP 8.2, 8.3 vs. 8.4.