### PR TITLE
Optimize copy operation logic in Parser.php

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -218,11 +218,19 @@ class Parser implements ParserInterface
 
             // find longest copy operation for the current segments
             $best_copy_length = 0;
-
-            $from_base_fragment_index = $from_segment_start;
             $cached_array_keys_for_current_segment = [];
 
-            while ($from_base_fragment_index < $from_segment_end) {
+            $from_fragment_keys = array_keys($from_fragments);
+
+            foreach ($from_fragment_keys as $from_base_fragment_index) {
+                if ($from_base_fragment_index < $from_segment_start) {
+                    continue;
+                }
+
+                if ($from_base_fragment_index >= $from_segment_end) {
+                    break;
+                }
+
                 $from_base_fragment        = $from_fragments[$from_base_fragment_index];
                 $from_base_fragment_length = mb_strlen($from_base_fragment);
 
@@ -276,7 +284,11 @@ class Parser implements ParserInterface
                             break;
                         }
 
-                        if ($from_fragments[$fragment_from_index] !== $to_fragments[$fragment_to_index]) {
+                        if (
+                            !isset($from_fragments[$fragment_from_index]) ||
+                            !isset($to_fragments[$fragment_to_index]) ||
+                            $from_fragments[$fragment_from_index] !== $to_fragments[$fragment_to_index]
+                        ) {
                             break;
                         }
 
@@ -290,8 +302,6 @@ class Parser implements ParserInterface
                         $best_to_start    = $to_base_fragment_index;
                     }
                 }
-
-                $from_base_fragment_index += mb_strlen($from_base_fragment);
 
                 // If match is larger than half segment size, no point trying to find better
                 // @todo: Really?


### PR DESCRIPTION
Hello, a problem i have right now :
As soon as I put an accented character or comma, i have a "Undefined array key 13 (or other number)" on Parser.php line 226.

With diacritics : 
<img width="371" height="56" alt="image" src="https://github.com/user-attachments/assets/f965011b-d735-4038-b6f2-9f1c140eddf4" />
Without : 
<img width="345" height="47" alt="image" src="https://github.com/user-attachments/assets/f8fc78d4-964f-4f54-bbda-84fa6d4b2649" />

<img width="1733" height="145" alt="image" src="https://github.com/user-attachments/assets/3a220699-5829-4b2c-8c4a-a851f490ac47" />


<img width="748" height="344" alt="image" src="https://github.com/user-attachments/assets/2cb093b0-efa2-4f98-b0a7-b91eacd87b76" />
<img width="1289" height="660" alt="image" src="https://github.com/user-attachments/assets/7d1899a2-e050-4431-bf01-ee14a45e7a60" />
<img width="1724" height="953" alt="image" src="https://github.com/user-attachments/assets/e4559544-cf80-4df2-8a54-f654b02a6b6b" />



The fix that I propose corrects the problem, whether with or without accents.
This "fix" corrects the error, but perhaps not the origin of the problem.
Refactor copy operation logic for better performance and clarity by caching array keys and improving condition checks.

Thanks for help.